### PR TITLE
Ignore unusedStructMember in cppcheck for arduino

### DIFF
--- a/.github/workflows/arduino_quality_check.yml
+++ b/.github/workflows/arduino_quality_check.yml
@@ -41,4 +41,4 @@ jobs:
           packages: cppcheck
           version: 1.0
       - name: cppcheck
-        run: cppcheck --std=c++11 --language=c++ --error-exitcode=1 --enable=warning,style,performance,portability --suppress=unreadVariable src/*
+        run: cppcheck --std=c++11 --language=c++ --error-exitcode=1 --enable=warning,style,performance,portability --suppress=unreadVariable --suppress=unusedStructMember src/*


### PR DESCRIPTION
unusedStructMember is problematic for driver headers