### PR TITLE
Fix metadata check on pull_request trigger

### DIFF
--- a/.github/workflows/driver.generated.metadata_check.yml
+++ b/.github/workflows/driver.generated.metadata_check.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ${{ inputs.run-environment }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # checkout last real commit, not the generated pull request commit
+          # variable is empty in case it runs on push, thus normal branch checkout will happen
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Check metadata exitst
         run: |
           if ! [ -f "metadata.yml" ]; then


### PR DESCRIPTION
pull request create a merge request commit on top, thus if we check for the last commit when the job trigger is pull_request we get that pull request commit by default as the last commit, but for our metadata check we need the last real commit