### PR TITLE
Allow existing Release in Release Job

### DIFF
--- a/.github/workflows/driver.common.github_release.yml
+++ b/.github/workflows/driver.common.github_release.yml
@@ -19,11 +19,10 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >-
-          gh release create
-          '${{ github.ref_name }}'
-          --repo '${{ github.repository }}'
-          --notes "${{ inputs.release-notes }}"
+        run: |
+          if [[ "$(gh release view '${{ github.ref_name }}' 2>&1)" == "release not found" ]]; then
+            gh release create '${{ github.ref_name }}' --repo '${{ github.repository }}' --notes "${{ inputs.release-notes }}"
+          fi
       - name: Upload metadata.yml to GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
do not create a release in the github-release job if release already exists
this allows us to create tag/releases from Github UI, as you cannot create a tag without a release in Github UI