### PR TITLE
Update cppcheck for arduino

### DIFF
--- a/.github/workflows/driver.arduino.check.yml
+++ b/.github/workflows/driver.arduino.check.yml
@@ -38,4 +38,4 @@ jobs:
           packages: cppcheck
           version: 1.0
       - name: cppcheck
-        run: cppcheck --std=c++11 --language=c++ --error-exitcode=1 --enable=warning,style,performance,portability --suppress=unreadVariable --suppress=unusedStructMember src/*
+        run: cppcheck --std=c++11 --language=c++ --error-exitcode=1 --enable=warning,style,performance,portability --suppress=unreadVariable --suppress=unusedStructMember --suppress=cstyleCast src/*


### PR DESCRIPTION
allow C-Style cast in Arduino c++ check

with an update of cppcheck the c-style cast are no longer allowed but the DriverGenerator uses C-Style cast for C and C++ targets, thus we suppress those warnings