### PR TITLE
Fix Python Sigstore action

### DIFF
--- a/.github/workflows/shared.python.pypi_publish.yml
+++ b/.github/workflows/shared.python.pypi_publish.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           gh release upload '${{ github.ref_name }}' dist/** --repo '${{ github.repository }}'
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3
+        uses: sigstore/gh-action-sigstore-python@v3.3.0
         with:
           inputs: >-
             ./dist/*.tar.gz


### PR DESCRIPTION
sigstore does not follow common guidelines to have a v3 tag that reference the latest release. Therefore we have to select the specific v3.3.0 release.